### PR TITLE
Define Recommendation type and use in dashboard

### DIFF
--- a/src/app/api/recommend/route.ts
+++ b/src/app/api/recommend/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { industrySkills, courses } from "@/lib/data";
 import { getRecommendations } from "@/lib/recommendation-model";
+import { Recommendation } from "@/types/recommendation";
 
 export async function POST(request: NextRequest) {
   try {
@@ -13,7 +14,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const recommendations = getRecommendations(skills, industrySkills, courses);
+    const recommendations: Recommendation[] = getRecommendations(
+      skills,
+      industrySkills,
+      courses
+    );
 
     return NextResponse.json({ recommendations });
   } catch (error) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import type React from "react";
 
 import { useState } from "react";
+import { Recommendation } from "@/types/recommendation";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -35,7 +36,7 @@ export default function Dashboard() {
   const [file, setFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [skills, setSkills] = useState<string[]>([]);
-  const [recommendations, setRecommendations] = useState<any[]>([]);
+  const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
   const [activeTab, setActiveTab] = useState("profile");
   const [error, setError] = useState<string | null>(null);
   const [cvText, setCvText] = useState<string | null>(null);

--- a/src/components/skill-gap-card.tsx
+++ b/src/components/skill-gap-card.tsx
@@ -13,18 +13,10 @@ import { Badge } from "@/components/ui/badge";
 import { CheckCircle, XCircle, BookOpen } from "lucide-react";
 import { useState } from "react";
 import Link from "next/link";
+import { Recommendation } from "@/types/recommendation";
 
 interface SkillGapCardProps {
-  recommendation: {
-    role: string;
-    matchPercentage: number;
-    existingSkills: string[];
-    missingSkills: string[];
-    recommendedCourses: {
-      code: string;
-      name: string;
-    }[];
-  };
+  recommendation: Recommendation;
 }
 
 export function SkillGapCard({ recommendation }: SkillGapCardProps) {

--- a/src/lib/recommendation-model.ts
+++ b/src/lib/recommendation-model.ts
@@ -9,16 +9,7 @@ interface Course {
   skills: string[];
 }
 
-interface Recommendation {
-  role: string;
-  matchPercentage: number;
-  existingSkills: string[];
-  missingSkills: string[];
-  recommendedCourses: {
-    code: string;
-    name: string;
-  }[];
-}
+import { Recommendation } from "@/types/recommendation";
 
 // Dictionary mapping various variants to a common normalized skill.
 const SKILL_SYNONYMS: Record<string, string> = {

--- a/src/types/recommendation.ts
+++ b/src/types/recommendation.ts
@@ -1,0 +1,10 @@
+export interface Recommendation {
+  role: string;
+  matchPercentage: number;
+  existingSkills: string[];
+  missingSkills: string[];
+  recommendedCourses: {
+    code: string;
+    name: string;
+  }[];
+}


### PR DESCRIPTION
## Summary
- add a Recommendation interface
- use Recommendation array in Dashboard state
- update SkillGapCard props and recommendation API to use the new type
- import Recommendation in recommendation model

## Testing
- `npm run lint` *(fails: `next: not found`)*