### PR TITLE
Fix typos in skills section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -219,8 +219,8 @@ export default function Home() {
                       Add Your Skills
                     </h3>
                     <p className="text-muted-foreground">
-                      Add the skills that you hace learned from your courses and
-                      your work experience to get depper and better insights.
+                      Add the skills that you have learned from your courses and
+                      your work experience to get deeper and better insights.
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- fix typos in the page header text

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: Exit handler never called)*